### PR TITLE
Adding support for Smart Star Projector device class (xktyd)

### DIFF
--- a/custom_components/smartlife/const.py
+++ b/custom_components/smartlife/const.py
@@ -65,6 +65,7 @@ class WorkMode(StrEnum):
     """Work modes."""
 
     COLOUR = "colour"
+    MANUAL = "manual"
     MUSIC = "music"
     SCENE = "scene"
     WHITE = "white"
@@ -143,6 +144,7 @@ class DPCode(StrEnum):
     COLOUR_DATA = "colour_data"  # Colored light mode
     COLOUR_DATA_HSV = "colour_data_hsv"  # Colored light mode
     COLOUR_DATA_V2 = "colour_data_v2"  # Colored light mode
+    COLOUR_SWITCH = "colour_switch"
     COOK_TEMPERATURE = "cook_temperature"
     COOK_TIME = "cook_time"
     CONCENTRATION_SET = "concentration_set"  # Concentration setting
@@ -202,6 +204,8 @@ class DPCode(StrEnum):
     HUMIDITY_SET = "humidity_set"  # Humidity setting
     HUMIDITY_VALUE = "humidity_value"  # Humidity
     IPC_WORK_MODE = "ipc_work_mode"
+    LASER_BRIGHT = "laser_bright"
+    LASER_SWITCH = "laser_switch"
     LED_TYPE_1 = "led_type_1"
     LED_TYPE_2 = "led_type_2"
     LED_TYPE_3 = "led_type_3"
@@ -276,6 +280,7 @@ class DPCode(StrEnum):
     SOS_STATE = "sos_state"  # Emergency mode
     SPEED = "speed"  # Speed level
     SPRAY_MODE = "spray_mode"  # Spraying mode
+    STAR_WORK_MODE = "star_work_mode"
     START = "start"  # Start
     STATUS = "status"
     STERILIZATION = "sterilization"  # Sterilization

--- a/custom_components/smartlife/fan.py
+++ b/custom_components/smartlife/fan.py
@@ -30,6 +30,7 @@ SMART_LIFE_SUPPORT_TYPE = {
     "fskg",  # Fan wall switch
     "kj",  # Air Purifier
     "cs",  # Dehumidifier
+    "xktyd", # Smart Star Projector motor and motor speed are reported as fan
 }
 
 
@@ -244,6 +245,11 @@ class SmartLifeFanEntity(SmartLifeEntity, FanEntity):
         if self._speed is not None:
             if (value := self.device.status.get(self._speed.dpcode)) is None:
                 return None
+
+            # Sometimes an int_type has its value stored as a str, so we have to cast
+            if type(value) is str:
+                value = int(value)
+
             return int(self._speed.remap_value_to(value, 1, 100))
 
         if self._speeds is not None:

--- a/custom_components/smartlife/number.py
+++ b/custom_components/smartlife/number.py
@@ -307,6 +307,15 @@ NUMBERS: dict[str, tuple[NumberEntityDescription, ...]] = {
             icon="mdi:thermometer-lines",
         ),
     ),
+    "xktyd": (
+        NumberEntityDescription(
+            key=DPCode.COUNTDOWN,
+            name="Countdown",
+            device_class=NumberDeviceClass.DURATION,
+            icon="mdi:timer-cog-outline",
+            translation_key="countdown",
+        ),
+    )
 }
 
 
@@ -410,6 +419,10 @@ class SmartLifeNumberEntity(SmartLifeEntity, NumberEntity):
         # Raw value
         if (value := self.device.status.get(self.entity_description.key)) is None:
             return None
+
+        # Sometimes an int_type has its value stored as a str, so we have to cast
+        if type(value) is str:
+            value = int(value)
 
         return self._number.scale_value(value)
 


### PR DESCRIPTION
This device class is not documented officially by the manufacturer, who has taken some liberties in using official DPCodes and creating custom ones.

The device consists of a nebula light, a laser projector, and a motor that rotates them. It offers three work modes: manual, scene, and music. However, I have only been able to implement the manual mode as I could not locate the payload documentation for the other two modes.

The motor control is exposed using fan DPCodes, it would be nice to refactor the fan entity implementation to support HA FanEntityDescription, so we could correctly set the entity name and use custom icons.