### PR TITLE
Support AM43(Zigbee) Blind drive motor

### DIFF
--- a/custom_components/smartlife/const.py
+++ b/custom_components/smartlife/const.py
@@ -358,6 +358,7 @@ class DPCode(StrEnum):
     WIRELESS_ELECTRICITY = "wireless_electricity"
     WORK_MODE = "work_mode"  # Working mode
     WORK_POWER = "work_power"
+    WORK_STATE = "work_state"
     ADD_ELE = "add_ele"
 
 
@@ -560,6 +561,3 @@ for uom in UNITS:
         DEVICE_CLASS_UNITS.setdefault(device_class, {})[uom.unit] = uom
         for unit_alias in uom.aliases:
             DEVICE_CLASS_UNITS[device_class][unit_alias] = uom
-
-
-

--- a/custom_components/smartlife/cover.py
+++ b/custom_components/smartlife/cover.py
@@ -360,7 +360,6 @@ class SmartLifeCoverEntity(SmartLifeEntity, CoverEntity):
             )
 
         self._send_command(commands)
-        self.async_schedule_update_ha_state()
 
     def close_cover(self, **kwargs: Any) -> None:
         """Close cover."""
@@ -388,7 +387,6 @@ class SmartLifeCoverEntity(SmartLifeEntity, CoverEntity):
             )
 
         self._send_command(commands)
-        self.async_schedule_update_ha_state()
 
     def set_cover_position(self, **kwargs: Any) -> None:
         """Move the cover to a specific position."""
@@ -410,7 +408,6 @@ class SmartLifeCoverEntity(SmartLifeEntity, CoverEntity):
                 }
             ]
         )
-        self.async_schedule_update_ha_state()
 
     def stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""
@@ -422,7 +419,6 @@ class SmartLifeCoverEntity(SmartLifeEntity, CoverEntity):
                 }
             ]
         )
-        self.async_schedule_update_ha_state()
 
     def set_cover_tilt_position(self, **kwargs: Any) -> None:
         """Move the cover tilt to a specific position."""
@@ -441,4 +437,3 @@ class SmartLifeCoverEntity(SmartLifeEntity, CoverEntity):
                 }
             ]
         )
-        self.async_schedule_update_ha_state()


### PR DESCRIPTION
- Support for product_id "zah67ekd"
- Addition of is_opening, is_closing properties
- Support for devices whose Open/Close status is reversed
- ~~Proactively notify HA of state changes when executing commands~~

The existing curtain settings were unstable in supporting AM43 (Zigbee), so I fixed it.

I've fixed it for backwards compatibility, but please let us know if you encounter any problems.

The following is the debug log for AM43 (Zigbee).

```log
2023-11-28 10:15:44.604 DEBUG (MainThread) [custom_components.smartlife] dpcode get device=CustomerDevice(active_time=1700483147, biz_type=18, category='cl', create_time=1700483147, icon='smart/icon/ay1520042877959dqQoX/cabc06d56803a5a189c9fff9fc78c56b.png', id='ebc769bdeae5xxxxxxxxxx', ip='', lat='xx.2500', local_key='xxxxxxxxxxxxxxxx', lon='xxx.8800', model='AM43', name='AM43-Zigbee', node_id='048727fffe4f23b7', online=True, owner_id='xxxxxxxxx', product_id='zah67ekd', product_name='AM43拉绳电机-Zigbee', status={'control': 'stop', 'percent_control': 0, 'percent_state': 0, 'control_back_mode': 'back', 'work_state': 'closing', 'situation_set': 'fully_open', 'fault': 0}, sub=True, time_zone='+09:00', uid='xxxxxxxxxxxxxxxxxxxx', update_time=1700483147, uuid='xxxxxxxxxxxxxxxx', function={'control': DeviceFunction(code='control', type='Enum', values='{"range":["open","stop","close","continue"]}'), 'percent_control': DeviceFunction(code='percent_control', type='Integer', values='{"unit":"%","min":0,"max":100,"scale":0,"step":1}'), 'control_back_mode': DeviceFunction(code='control_back_mode', type='Enum', values='{"range":["forward","back"]}')}, status_range={'control': DeviceStatusRange(code='control', type='Enum', values='{"range":["open","stop","close","continue"]}'), 'percent_control': DeviceStatusRange(code='percent_control', type='Integer', values='{"unit":"%","min":0,"max":100,"scale":0,"step":1}'), 'percent_state': DeviceStatusRange(code='percent_state', type='Integer', values='{"unit":"%","min":0,"max":100,"scale":0,"step":1}'), 'control_back_mode': DeviceStatusRange(code='control_back_mode', type='Enum', values='{"range":["forward","back"]}'), 'work_state': DeviceStatusRange(code='work_state', type='Enum', values='{"range":["opening","closing"]}'), 'situation_set': DeviceStatusRange(code='situation_set', type='Enum', values='{"range":["fully_open","fully_close"]}'), 'fault': DeviceStatusRange(code='fault', type='Bitmap', values='{"label":["motor_fault"]}')}, support_local=True, local_strategy={1: {'value_convert': 'default', 'status_code': 'control', 'config_item': {'statusFormat': '{"control":"$"}', 'valueDesc': '{"range":["open","stop","close","continue"]}', 'valueType': 'Enum', 'enumMappingMap': {}, 'pid': 'zah67ekd'}}, 2: {'value_convert': 'default', 'status_code': 'percent_control', 'config_item': {'statusFormat': '{"percent_control":"$"}', 'valueDesc': '{"unit":"%","min":0,"max":100,"scale":0,"step":1}', 'valueType': 'Integer', 'enumMappingMap': {}, 'pid': 'zah67ekd'}}, 3: {'value_convert': 'default', 'status_code': 'percent_state', 'config_item': {'statusFormat': '{"percent_state":"$"}', 'valueDesc': '{"unit":"%","min":0,"max":100,"scale":0,"step":1}', 'valueType': 'Integer', 'enumMappingMap': {}, 'pid': 'zah67ekd'}}, 5: {'value_convert': 'default', 'status_code': 'control_back_mode', 'config_item': {'statusFormat': '{"control_back_mode":"$"}', 'valueDesc': '{"range":["forward","back"]}', 'valueType': 'Enum', 'enumMappingMap': {}, 'pid': 'zah67ekd'}}, 7: {'value_convert': 'default', 'status_code': 'work_state', 'config_item': {'statusFormat': '{"work_state":"$"}', 'valueDesc': '{"range":["opening","closing"]}', 'valueType': 'Enum', 'enumMappingMap': {}, 'pid': 'zah67ekd'}}, 11: {'value_convert': 'default', 'status_code': 'situation_set', 'config_item': {'statusFormat': '{"situation_set":"$"}', 'valueDesc': '{"range":["fully_open","fully_close"]}', 'valueType': 'Enum', 'enumMappingMap': {}, 'pid': 'zah67ekd'}}, 12: {'value_convert': 'default', 'status_code': 'fault', 'config_item': {'statusFormat': '{"fault":"$"}', 'valueDesc': '{"label":["motor_fault"]}', 'valueType': 'Bitmap', 'enumMappingMap': {}, 'pid': 'zah67ekd'}}}, set_up=True) dpcode=percent_state key=status_range


2023-11-28 10:10:41.995 DEBUG (SyncWorker_7) [custom_components.smartlife] Sending commands for device ebc769bdeae5xxxxxxxxxx: [{'code': <DPCode.CONTROL: 'control'>, 'value': 'open'}, {'code': <DPCode.PERCENT_CONTROL: 'percent_control'>, 'value': 100}]
2023-11-28 10:10:43.995 DEBUG (Thread-7 (_thread_main)) [custom_components.smartlife] Received update for device ebc769bdeae5xxxxxxxxxx: {'control': 'open', 'percent_control': 0, 'percent_state': 0, 'control_back_mode': 'back', 'work_state': 'closing', 'situation_set': 'fully_open', 'fault': 0}
2023-11-28 10:10:52.555 DEBUG (SyncWorker_6) [custom_components.smartlife] Sending commands for device ebc769bdeae5xxxxxxxxxx: [{'code': <DPCode.CONTROL: 'control'>, 'value': 'open'}, {'code': <DPCode.PERCENT_CONTROL: 'percent_control'>, 'value': 100}]
2023-11-28 10:10:53.731 DEBUG (Thread-7 (_thread_main)) [custom_components.smartlife] Received update for device ebc769bdeae5xxxxxxxxxx: {'control': 'open', 'percent_control': 0, 'percent_state': 100, 'control_back_mode': 'back', 'work_state': 'closing', 'situation_set': 'fully_open', 'fault': 0}
2023-11-28 10:10:54.099 DEBUG (Thread-7 (_thread_main)) [custom_components.smartlife] Received update for device ebc769bdeae5xxxxxxxxxx: {'control': 'stop', 'percent_control': 0, 'percent_state': 100, 'control_back_mode': 'back', 'work_state': 'closing', 'situation_set': 'fully_open', 'fault': 0}
2023-11-28 10:11:04.088 DEBUG (Thread-7 (_thread_main)) [custom_components.smartlife] Received update for device ebc769bdeae5xxxxxxxxxx: {'control': 'stop', 'percent_control': 100, 'percent_state': 100, 'control_back_mode': 'back', 'work_state': 'closing', 'situation_set': 'fully_open', 'fault': 0}
2023-11-28 10:11:15.370 DEBUG (SyncWorker_0) [custom_components.smartlife] Sending commands for device ebc769bdeae5xxxxxxxxxx: [{'code': <DPCode.CONTROL: 'control'>, 'value': 'close'}, {'code': <DPCode.PERCENT_CONTROL: 'percent_control'>, 'value': 0}]
2023-11-28 10:11:16.527 DEBUG (Thread-7 (_thread_main)) [custom_components.smartlife] Received update for device ebc769bdeae5xxxxxxxxxx: {'control': 'close', 'percent_control': 100, 'percent_state': 100, 'control_back_mode': 'back', 'work_state': 'closing', 'situation_set': 'fully_open', 'fault': 0}
2023-11-28 10:11:26.152 DEBUG (Thread-7 (_thread_main)) [custom_components.smartlife] Received update for device ebc769bdeae5xxxxxxxxxx: {'control': 'close', 'percent_control': 100, 'percent_state': 0, 'control_back_mode': 'back', 'work_state': 'closing', 'situation_set': 'fully_open', 'fault': 0}
2023-11-28 10:11:26.379 DEBUG (Thread-7 (_thread_main)) [custom_components.smartlife] Received update for device ebc769bdeae5xxxxxxxxxx: {'control': 'close', 'percent_control': 0, 'percent_state': 0, 'control_back_mode': 'back', 'work_state': 'closing', 'situation_set': 'fully_open', 'fault': 0}
2023-11-28 10:11:38.585 DEBUG (SyncWorker_9) [custom_components.smartlife] Sending commands for device ebc769bdeae5xxxxxxxxxx: [{'code': <DPCode.PERCENT_CONTROL: 'percent_control'>, 'value': 50}]
2023-11-28 10:11:41.131 DEBUG (Thread-7 (_thread_main)) [custom_components.smartlife] Received update for device ebc769bdeae5xxxxxxxxxx: {'control': 'close', 'percent_control': 50, 'percent_state': 0, 'control_back_mode': 'back', 'work_state': 'closing', 'situation_set': 'fully_open', 'fault': 0}
2023-11-28 10:11:41.324 DEBUG (Thread-7 (_thread_main)) [custom_components.smartlife] Received update for device ebc769bdeae5xxxxxxxxxx: {'control': 'close', 'percent_control': 50, 'percent_state': 0, 'control_back_mode': 'back', 'work_state': 'opening', 'situation_set': 'fully_open', 'fault': 0}
2023-11-28 10:11:41.482 DEBUG (Thread-7 (_thread_main)) [custom_components.smartlife] Received update for device ebc769bdeae5xxxxxxxxxx: {'control': 'open', 'percent_control': 50, 'percent_state': 0, 'control_back_mode': 'back', 'work_state': 'opening', 'situation_set': 'fully_open', 'fault': 0}
2023-11-28 10:11:46.196 DEBUG (Thread-7 (_thread_main)) [custom_components.smartlife] Received update for device ebc769bdeae5xxxxxxxxxx: {'control': 'open', 'percent_control': 50, 'percent_state': 50, 'control_back_mode': 'back', 'work_state': 'opening', 'situation_set': 'fully_open', 'fault': 0}
2023-11-28 10:11:46.526 DEBUG (Thread-7 (_thread_main)) [custom_components.smartlife] Received update for device ebc769bdeae5xxxxxxxxxx: {'control': 'stop', 'percent_control': 50, 'percent_state': 50, 'control_back_mode': 'back', 'work_state': 'opening', 'situation_set': 'fully_open', 'fault': 0}
2023-11-28 10:11:49.138 DEBUG (SyncWorker_4) [custom_components.smartlife] Sending commands for device ebc769bdeae5xxxxxxxxxx: [{'code': <DPCode.PERCENT_CONTROL: 'percent_control'>, 'value': 100}]
2023-11-28 10:11:49.983 DEBUG (Thread-7 (_thread_main)) [custom_components.smartlife] Received update for device ebc769bdeae5xxxxxxxxxx: {'control': 'stop', 'percent_control': 100, 'percent_state': 50, 'control_back_mode': 'back', 'work_state': 'opening', 'situation_set': 'fully_open', 'fault': 0}
2023-11-28 10:11:54.135 DEBUG (Thread-7 (_thread_main)) [custom_components.smartlife] Received update for device eb449b2a4186c3092d7l5s: {'control': 'stop', 'percent_control': 3, 'percent_state': 3, 'control_back_mode': 'back', 'work_state': 'opening', 'situation_set': 'fully_open', 'fault': 0}
2023-11-28 10:11:55.164 DEBUG (Thread-7 (_thread_main)) [custom_components.smartlife] Received update for device ebc769bdeae5xxxxxxxxxx: {'control': 'stop', 'percent_control': 100, 'percent_state': 100, 'control_back_mode': 'back', 'work_state': 'opening', 'situation_set': 'fully_open', 'fault': 0}
2023-11-28 10:12:00.993 DEBUG (SyncWorker_1) [custom_components.smartlife] Sending commands for device ebc769bdeae5xxxxxxxxxx: [{'code': <DPCode.PERCENT_CONTROL: 'percent_control'>, 'value': 50}]
2023-11-28 10:12:02.144 DEBUG (Thread-7 (_thread_main)) [custom_components.smartlife] Received update for device ebc769bdeae5xxxxxxxxxx: {'control': 'stop', 'percent_control': 50, 'percent_state': 100, 'control_back_mode': 'back', 'work_state': 'opening', 'situation_set': 'fully_open', 'fault': 0}
2023-11-28 10:12:02.275 DEBUG (Thread-7 (_thread_main)) [custom_components.smartlife] Received update for device ebc769bdeae5xxxxxxxxxx: {'control': 'stop', 'percent_control': 50, 'percent_state': 100, 'control_back_mode': 'back', 'work_state': 'closing', 'situation_set': 'fully_open', 'fault': 0}
2023-11-28 10:12:03.462 DEBUG (Thread-7 (_thread_main)) [custom_components.smartlife] Received update for device ebc769bdeae5xxxxxxxxxx: {'control': 'close', 'percent_control': 50, 'percent_state': 100, 'control_back_mode': 'back', 'work_state': 'closing', 'situation_set': 'fully_open', 'fault': 0}
2023-11-28 10:12:04.619 DEBUG (Thread-7 (_thread_main)) [custom_components.smartlife] Received update for device eb449b2a4186c3092d7l5s: {'control': 'stop', 'percent_control': 3, 'percent_state': 3, 'control_back_mode': 'back', 'work_state': 'opening', 'situation_set': 'fully_open', 'fault': 0}
2023-11-28 10:12:07.229 DEBUG (Thread-7 (_thread_main)) [custom_components.smartlife] Received update for device ebc769bdeae5xxxxxxxxxx: {'control': 'close', 'percent_control': 50, 'percent_state': 49, 'control_back_mode': 'back', 'work_state': 'closing', 'situation_set': 'fully_open', 'fault': 0}
2023-11-28 10:12:07.461 DEBUG (Thread-7 (_thread_main)) [custom_components.smartlife] Received update for device ebc769bdeae5xxxxxxxxxx: {'control': 'stop', 'percent_control': 50, 'percent_state': 49, 'control_back_mode': 'back', 'work_state': 'closing', 'situation_set': 'fully_open', 'fault': 0}
2023-11-28 10:12:09.682 DEBUG (SyncWorker_2) [custom_components.smartlife] Sending commands for device ebc769bdeae5xxxxxxxxxx: [{'code': <DPCode.PERCENT_CONTROL: 'percent_control'>, 'value': 0}]
2023-11-28 10:12:11.400 DEBUG (Thread-7 (_thread_main)) [custom_components.smartlife] Received update for device ebc769bdeae5xxxxxxxxxx: {'control': 'close', 'percent_control': 50, 'percent_state': 49, 'control_back_mode': 'back', 'work_state': 'closing', 'situation_set': 'fully_open', 'fault': 0}
2023-11-28 10:12:16.291 DEBUG (Thread-7 (_thread_main)) [custom_components.smartlife] Received update for device ebc769bdeae5xxxxxxxxxx: {'control': 'close', 'percent_control': 50, 'percent_state': 0, 'control_back_mode': 'back', 'work_state': 'closing', 'situation_set': 'fully_open', 'fault': 0}
2023-11-28 10:12:16.382 DEBUG (Thread-7 (_thread_main)) [custom_components.smartlife] Received update for device ebc769bdeae5xxxxxxxxxx: {'control': 'stop', 'percent_control': 50, 'percent_state': 0, 'control_back_mode': 'back', 'work_state': 'closing', 'situation_set': 'fully_open', 'fault': 0}
```