### PR TITLE
Mjj category.

### DIFF
--- a/custom_components/smartlife/const.py
+++ b/custom_components/smartlife/const.py
@@ -358,6 +358,7 @@ class DPCode(StrEnum):
     WIRELESS_ELECTRICITY = "wireless_electricity"
     WORK_MODE = "work_mode"  # Working mode
     WORK_POWER = "work_power"
+    WORK_STATE = "work_state"
     ADD_ELE = "add_ele"
 
 

--- a/custom_components/smartlife/number.py
+++ b/custom_components/smartlife/number.py
@@ -306,6 +306,16 @@ NUMBERS: dict[str, tuple[NumberEntityDescription, ...]] = {
             device_class=NumberDeviceClass.TEMPERATURE,
             icon="mdi:thermometer-lines",
         ),
+    ),    
+    # Smart Towel Rack
+    # https://developer.tuya.com/en/docs/iot/categorymjj?id=Kakkmlm9k4cir
+    "mjj": (
+        NumberEntityDescription(
+            key=DPCode.TEMP_SET,
+            name="Temperature",
+            device_class=NumberDeviceClass.TEMPERATURE,
+            icon="mdi:thermometer-lines",
+        ),
     ),
 }
 

--- a/custom_components/smartlife/select.py
+++ b/custom_components/smartlife/select.py
@@ -359,6 +359,17 @@ SELECTS: dict[str, tuple[SelectEntityDescription, ...]] = {
             icon="mdi:water-percent",
         ),
     ),
+    # Smart Towel Rack
+    # https://developer.tuya.com/en/docs/iot/categorymjj?id=Kakkmlm9k4cir
+    "mjj": (
+        SelectEntityDescription(
+            key=DPCode.COUNTDOWN_SET,
+            name="Countdown",
+            entity_category=EntityCategory.CONFIG,
+            icon="mdi:timer-cog-outline",
+            translation_key="countdown",
+        ),
+    ),
 }
 
 # Socket (duplicate of `kg`)

--- a/custom_components/smartlife/sensor.py
+++ b/custom_components/smartlife/sensor.py
@@ -1046,6 +1046,28 @@ SENSORS: dict[str, tuple[SmartLifeSensorEntityDescription, ...]] = {
             state_class=SensorStateClass.MEASUREMENT,
         ),
     ),
+    # Smart Towel Rack
+    # https://developer.tuya.com/en/docs/iot/categorymjj?id=Kakkmlm9k4cir
+    "mjj": (
+        SmartLifeSensorEntityDescription(
+            key=DPCode.TEMP_CURRENT,
+            name="Temperature",
+            device_class=SensorDeviceClass.TEMPERATURE,
+            state_class=SensorStateClass.MEASUREMENT,
+        ),
+        SmartLifeSensorEntityDescription(
+            key=DPCode.COUNTDOWN_LEFT,
+            name="Countdown left",
+            device_class=SensorDeviceClass.DURATION,
+            state_class=SensorStateClass.MEASUREMENT,
+        ),
+        SmartLifeSensorEntityDescription(
+            key=DPCode.WORK_STATE,
+            name="Work state",
+            icon="mdi:eye",
+            entity_category=EntityCategory.DIAGNOSTIC,
+        ),
+    ),
 }
 
 # Socket (duplicate of `kg`)

--- a/custom_components/smartlife/sensor.py
+++ b/custom_components/smartlife/sensor.py
@@ -1051,7 +1051,7 @@ SENSORS: dict[str, tuple[SmartLifeSensorEntityDescription, ...]] = {
     "mjj": (
         SmartLifeSensorEntityDescription(
             key=DPCode.TEMP_CURRENT,
-            name="Temperature",
+            name="Current temperature",
             device_class=SensorDeviceClass.TEMPERATURE,
             state_class=SensorStateClass.MEASUREMENT,
         ),

--- a/custom_components/smartlife/switch.py
+++ b/custom_components/smartlife/switch.py
@@ -703,7 +703,7 @@ SWITCHES: dict[str, tuple[SwitchEntityDescription, ...]] = {
         SwitchEntityDescription(
             key=DPCode.SWITCH,
             name="Power",
-            icon=" mdi:power-cycle",
+            icon=" mdi:power",
         ),
     ),
 }

--- a/custom_components/smartlife/switch.py
+++ b/custom_components/smartlife/switch.py
@@ -697,6 +697,15 @@ SWITCHES: dict[str, tuple[SwitchEntityDescription, ...]] = {
             entity_category=EntityCategory.CONFIG,
         ),
     ),
+    # Smart Towel Rack
+    # https://developer.tuya.com/en/docs/iot/categorymjj?id=Kakkmlm9k4cir
+    "mjj": (
+        SwitchEntityDescription(
+            key=DPCode.SWITCH,
+            name="Power",
+            icon=" mdi:power-cycle",
+        ),
+    ),
 }
 
 # Socket (duplicate of `pc`)

--- a/custom_components/smartlife/switch.py
+++ b/custom_components/smartlife/switch.py
@@ -703,7 +703,8 @@ SWITCHES: dict[str, tuple[SwitchEntityDescription, ...]] = {
         SwitchEntityDescription(
             key=DPCode.SWITCH,
             name="Power",
-            icon=" mdi:power",
+            icon="mdi:power",
+            entity_category=EntityCategory.CONFIG,
         ),
     ),
 }


### PR DESCRIPTION
Added the mjj category, for smart towel racks, all work, with the exception of the work_state, that is passed inverted from the framework upstream. It return heating while in standby, and viceversa 