### PR TITLE
Mjj category

### DIFF
--- a/custom_components/smartlife/const.py
+++ b/custom_components/smartlife/const.py
@@ -88,6 +88,7 @@ class DPCode(StrEnum):
     """
 
     AIR_QUALITY = "air_quality"
+    AIR_QUALITY_INDEX = "air_quality_index"
     ALARM_SWITCH = "alarm_switch"  # Alarm switch
     ALARM_TIME = "alarm_time"  # Alarm time
     ALARM_VOLUME = "alarm_volume"  # Alarm volume

--- a/custom_components/smartlife/const.py
+++ b/custom_components/smartlife/const.py
@@ -358,6 +358,7 @@ class DPCode(StrEnum):
     WIRELESS_ELECTRICITY = "wireless_electricity"
     WORK_MODE = "work_mode"  # Working mode
     WORK_POWER = "work_power"
+    WORK_STATE = "work_state"
     ADD_ELE = "add_ele"
 
 

--- a/custom_components/smartlife/const.py
+++ b/custom_components/smartlife/const.py
@@ -241,7 +241,9 @@ class DPCode(StrEnum):
     PM10 = "pm10"
     PM25 = "pm25"
     PM25_STATE = "pm25_state"
+    PM1_VALUE = "pm1_value"
     PM25_VALUE = "pm25_value"
+    PM10_VALUE = "pm10_value"
     POWDER_SET = "powder_set"  # Powder
     POWER = "power"
     POWER_GO = "power_go"

--- a/custom_components/smartlife/const.py
+++ b/custom_components/smartlife/const.py
@@ -241,9 +241,7 @@ class DPCode(StrEnum):
     PM10 = "pm10"
     PM25 = "pm25"
     PM25_STATE = "pm25_state"
-    PM1_VALUE = "pm1_value"
     PM25_VALUE = "pm25_value"
-    PM10_VALUE = "pm10_value"
     POWDER_SET = "powder_set"  # Powder
     POWER = "power"
     POWER_GO = "power_go"

--- a/custom_components/smartlife/number.py
+++ b/custom_components/smartlife/number.py
@@ -306,6 +306,16 @@ NUMBERS: dict[str, tuple[NumberEntityDescription, ...]] = {
             device_class=NumberDeviceClass.TEMPERATURE,
             icon="mdi:thermometer-lines",
         ),
+    ),    
+    # Smart Towel Rack
+    # https://developer.tuya.com/en/docs/iot/categorymjj?id=Kakkmlm9k4cir
+    "mjj": (
+        NumberEntityDescription(
+            key=DPCode.TEMP_SET,
+            name="Temperature",
+            device_class=NumberDeviceClass.TEMPERATURE,
+            icon="mdi:thermometer-lines",
+        ),
     ),
 }
 

--- a/custom_components/smartlife/select.py
+++ b/custom_components/smartlife/select.py
@@ -359,6 +359,17 @@ SELECTS: dict[str, tuple[SelectEntityDescription, ...]] = {
             icon="mdi:water-percent",
         ),
     ),
+    # Smart Towel Rack
+    # https://developer.tuya.com/en/docs/iot/categorymjj?id=Kakkmlm9k4cir
+    "mjj": (
+        SelectEntityDescription(
+            key=DPCode.COUNTDOWN_SET,
+            name="Countdown",
+            entity_category=EntityCategory.CONFIG,
+            icon="mdi:timer-cog-outline",
+            translation_key="countdown",
+        ),
+    ),
 }
 
 # Socket (duplicate of `kg`)

--- a/custom_components/smartlife/sensor.py
+++ b/custom_components/smartlife/sensor.py
@@ -1046,6 +1046,28 @@ SENSORS: dict[str, tuple[SmartLifeSensorEntityDescription, ...]] = {
             state_class=SensorStateClass.MEASUREMENT,
         ),
     ),
+    # Smart Towel Rack
+    # https://developer.tuya.com/en/docs/iot/categorymjj?id=Kakkmlm9k4cir
+    "mjj": (
+        SmartLifeSensorEntityDescription(
+            key=DPCode.TEMP_CURRENT,
+            name="Temperature",
+            device_class=SensorDeviceClass.TEMPERATURE,
+            state_class=SensorStateClass.MEASUREMENT,
+        ),
+        SmartLifeSensorEntityDescription(
+            key=DPCode.COUNTDOWN_LEFT,
+            name="Countdown left",
+            device_class=SensorDeviceClass.DURATION,
+            state_class=SensorStateClass.MEASUREMENT,
+        ),
+        SmartLifeSensorEntityDescription(
+            key=DPCode.WORK_STATE,
+            name="Work state",
+            icon="mdi:eye",
+            entity_category=EntityCategory.DIAGNOSTIC,
+        ),
+    ),
 }
 
 # Socket (duplicate of `kg`)

--- a/custom_components/smartlife/sensor.py
+++ b/custom_components/smartlife/sensor.py
@@ -293,6 +293,12 @@ SENSORS: dict[str, tuple[SmartLifeSensorEntityDescription, ...]] = {
             device_class=SensorDeviceClass.PM10,
             state_class=SensorStateClass.MEASUREMENT,
         ),
+        SmartLifeSensorEntityDescription(
+            key=DPCode.AIR_QUALITY_INDEX,
+            name="Air quality index",
+            icon="mdi:air-filter",
+            translation_key="air_quality_index",
+        ),
     ),
     # Formaldehyde Detector
     # Note: Not documented

--- a/custom_components/smartlife/sensor.py
+++ b/custom_components/smartlife/sensor.py
@@ -299,6 +299,14 @@ SENSORS: dict[str, tuple[SmartLifeSensorEntityDescription, ...]] = {
             icon="mdi:air-filter",
             translation_key="air_quality_index",
         ),
+        SmartLifeSensorEntityDescription(
+            key=DPCode.BATTERY_PERCENTAGE,
+            name="Battery",
+            native_unit_of_measurement=PERCENTAGE,
+            device_class=SensorDeviceClass.BATTERY,
+            state_class=SensorStateClass.MEASUREMENT,
+            entity_category=EntityCategory.DIAGNOSTIC,
+        ),
     ),
     # Formaldehyde Detector
     # Note: Not documented

--- a/custom_components/smartlife/sensor.py
+++ b/custom_components/smartlife/sensor.py
@@ -282,13 +282,13 @@ SENSORS: dict[str, tuple[SmartLifeSensorEntityDescription, ...]] = {
             state_class=SensorStateClass.MEASUREMENT,
         ),
         SmartLifeSensorEntityDescription(
-            key=DPCode.PM1_VALUE,
+            key=DPCode.PM1,
             name="Particulate matter 1 µm",
             device_class=SensorDeviceClass.PM1,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         SmartLifeSensorEntityDescription(
-            key=DPCode.PM10_VALUE,
+            key=DPCode.PM10,
             name="Particulate matter 10 µm",
             device_class=SensorDeviceClass.PM10,
             state_class=SensorStateClass.MEASUREMENT,

--- a/custom_components/smartlife/sensor.py
+++ b/custom_components/smartlife/sensor.py
@@ -281,6 +281,18 @@ SENSORS: dict[str, tuple[SmartLifeSensorEntityDescription, ...]] = {
             device_class=SensorDeviceClass.PM25,
             state_class=SensorStateClass.MEASUREMENT,
         ),
+        SmartLifeSensorEntityDescription(
+            key=DPCode.PM1_VALUE,
+            name="Particulate matter 1 µm",
+            device_class=SensorDeviceClass.PM1,
+            state_class=SensorStateClass.MEASUREMENT,
+        ),
+        SmartLifeSensorEntityDescription(
+            key=DPCode.PM10_VALUE,
+            name="Particulate matter 10 µm",
+            device_class=SensorDeviceClass.PM10,
+            state_class=SensorStateClass.MEASUREMENT,
+        ),
     ),
     # Formaldehyde Detector
     # Note: Not documented

--- a/custom_components/smartlife/sensor.py
+++ b/custom_components/smartlife/sensor.py
@@ -1051,7 +1051,7 @@ SENSORS: dict[str, tuple[SmartLifeSensorEntityDescription, ...]] = {
     "mjj": (
         SmartLifeSensorEntityDescription(
             key=DPCode.TEMP_CURRENT,
-            name="Temperature",
+            name="Current temperature",
             device_class=SensorDeviceClass.TEMPERATURE,
             state_class=SensorStateClass.MEASUREMENT,
         ),

--- a/custom_components/smartlife/strings.json
+++ b/custom_components/smartlife/strings.json
@@ -209,6 +209,13 @@
           "good": "Good",
           "severe": "Severe"
         }
+     "air_quality_index": {
+        "state": {
+          "level_1": "Great",
+          "level_2": "Mild",
+          "level_3": "Good",
+          "level_4": "Severe"
+        }
       }
     }
   }

--- a/custom_components/smartlife/switch.py
+++ b/custom_components/smartlife/switch.py
@@ -703,7 +703,7 @@ SWITCHES: dict[str, tuple[SwitchEntityDescription, ...]] = {
         SwitchEntityDescription(
             key=DPCode.SWITCH,
             name="Power",
-            icon=" mdi:power-cycle",
+            icon=" mdi:power",
         ),
     ),
 }

--- a/custom_components/smartlife/switch.py
+++ b/custom_components/smartlife/switch.py
@@ -697,6 +697,15 @@ SWITCHES: dict[str, tuple[SwitchEntityDescription, ...]] = {
             entity_category=EntityCategory.CONFIG,
         ),
     ),
+    # Smart Towel Rack
+    # https://developer.tuya.com/en/docs/iot/categorymjj?id=Kakkmlm9k4cir
+    "mjj": (
+        SwitchEntityDescription(
+            key=DPCode.SWITCH,
+            name="Power",
+            icon=" mdi:power-cycle",
+        ),
+    ),
 }
 
 # Socket (duplicate of `pc`)

--- a/custom_components/smartlife/switch.py
+++ b/custom_components/smartlife/switch.py
@@ -703,7 +703,8 @@ SWITCHES: dict[str, tuple[SwitchEntityDescription, ...]] = {
         SwitchEntityDescription(
             key=DPCode.SWITCH,
             name="Power",
-            icon=" mdi:power",
+            icon="mdi:power",
+            entity_category=EntityCategory.CONFIG,
         ),
     ),
 }

--- a/custom_components/smartlife/translations/en.json
+++ b/custom_components/smartlife/translations/en.json
@@ -197,6 +197,14 @@
                     "severe": "Severe"
                 }
             },
+            "air_quality_index": {
+                "state": {
+                    "level_1": "Good",
+                    "level_2": "Great",
+                    "level_3": "Mild",
+                    "level_4": "Severe"
+                },
+            },
             "status": {
                 "state": {
                     "boiling_temp": "Boiling temperature",

--- a/custom_components/smartlife/translations/en.json
+++ b/custom_components/smartlife/translations/en.json
@@ -203,7 +203,7 @@
                     "level_2": "Great",
                     "level_3": "Mild",
                     "level_4": "Severe"
-                },
+                }
             },
             "status": {
                 "state": {

--- a/custom_components/smartlife/translations/sensor.en.json
+++ b/custom_components/smartlife/translations/sensor.en.json
@@ -6,6 +6,12 @@
             "mild": "Mild",
             "severe": "Severe"
         },
+        "smartlife__air_quality_index": {
+            "level_1": "Good",
+            "level_2": "Great",
+            "level_3": "Mild",
+            "level_4": "Severe"
+        },
         "smartlife__status": {
             "boiling_temp": "Boiling temperature",
             "cooling": "Cooling",


### PR DESCRIPTION
Added the mjj category, for smart towel racks, all is tested working from several weeks, with the exception of the work_state, that is passed inverted from the framework upstream. It return heating while in standby, and viceversa.
The mjj category have more controls than my towel rack:
https://developer.tuya.com/en/docs/iot/categorymjj?id=Kakkmlm9k4cir
(For example my device not have the "child_lock"
But as my device does't use the full controls set, i wasn't able to code them