### PR TITLE
fix: Fixed  typo in Sound detection sensitivity entity description for smart cameras

### DIFF
--- a/custom_components/smartlife/select.py
+++ b/custom_components/smartlife/select.py
@@ -102,7 +102,7 @@ SELECTS: dict[str, tuple[SelectEntityDescription, ...]] = {
         ),
         SelectEntityDescription(
             key=DPCode.DECIBEL_SENSITIVITY,
-            name="Sound detection densitivity",
+            name="Sound detection sensitivity",
             icon="mdi:volume-vibrate",
             entity_category=EntityCategory.CONFIG,
             translation_key="decibel_sensitivity",


### PR DESCRIPTION
## Description

Fixed typo in the entity description of sound detection **d**ensitivity to **s**ensitivity

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested locally with a webcam that has the Sound Detection Sensitivity option.
Found that the enity was added with Devicename Sound Detection Sensitivity and id: devicename_sound_detection_sensitivity

- [X] Local Testing

## Diagnostic File

None needed, visual bug (typo)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules