### PR TITLE
Fix QR code generating without white background

### DIFF
--- a/custom_components/smartlife/config_flow.py
+++ b/custom_components/smartlife/config_flow.py
@@ -111,20 +111,11 @@ class SmartlifeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 def _generate_qr_code(data: str) -> str:
     """Generate a base64 PNG string represent QR Code image of data."""
     import pyqrcode  # pylint: disable=import-outside-toplevel
-
+#
     qr_code = pyqrcode.create(data)
+    image_as_str = qr_code.png_as_base64_str(scale=4) # PNG is generated as black and white by default
+    html_img = '<img src="data:image/png;base64,{}">'.format(image_as_str)
 
-    with BytesIO() as buffer:
-        qr_code.svg(file=buffer, scale=4)
-        return str(
-            buffer.getvalue()
-            .decode("ascii")
-            .replace("\n", "")
-            .replace(
-                (
-                    '<?xml version="1.0" encoding="UTF-8"?>'
-                    '<svg xmlns="http://www.w3.org/2000/svg"'
-                ),
-                "<svg",
-            )
-        )
+    LOGGER.debug("qr_code=%s", html_img)
+
+    return html_img

--- a/custom_components/smartlife/config_flow.py
+++ b/custom_components/smartlife/config_flow.py
@@ -111,11 +111,9 @@ class SmartlifeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 def _generate_qr_code(data: str) -> str:
     """Generate a base64 PNG string represent QR Code image of data."""
     import pyqrcode  # pylint: disable=import-outside-toplevel
-#
+
     qr_code = pyqrcode.create(data)
+
+    # Generate PNG as base64 string, this can't be modified by HA theme setting
     image_as_str = qr_code.png_as_base64_str(scale=4) # PNG is generated as black and white by default
-    html_img = '<img src="data:image/png;base64,{}">'.format(image_as_str)
-
-    LOGGER.debug("qr_code=%s", html_img)
-
-    return html_img
+    return '<img src="data:image/png;base64,{}">'.format(image_as_str)

--- a/custom_components/smartlife/manifest.json
+++ b/custom_components/smartlife/manifest.json
@@ -43,7 +43,10 @@
   "integration_type": "hub",
   "iot_class": "cloud_push",
   "version": "0.1.0",
-  "requirements": ["tuya-device-sharing-sdk==0.1.9"]
+  "requirements": [
+    "tuya-device-sharing-sdk==0.1.9",
+    "pypng==0.20220715.0"
+  ]
 
 
 }


### PR DESCRIPTION
## Description

Fix QR code generating without a white background. Changed to PNG as when testing HA theme was overwriting the SVG elements background colour.

- Change QR code generation to PNG
- Import pypng as a dependency

### After changes:

Light:
![image](https://github.com/tuya/tuya-smart-life/assets/12432932/3f7b3486-1d6c-4699-9a51-0255f760f081)

Dark:
![image](https://github.com/tuya/tuya-smart-life/assets/12432932/28a89c7f-7869-4a6b-ba08-248e906a16c0)

Fixes # [112](https://github.com/tuya/tuya-smart-life/issues/112)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Local Testing

## Diagnostic File

None needed, visual bug

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules