### PR TITLE
Fix Documentation URL in manifest.json

### DIFF
--- a/custom_components/smartlife/manifest.json
+++ b/custom_components/smartlife/manifest.json
@@ -39,7 +39,7 @@
       "macaddress": "D81F12*"
     }
   ],
-  "documentation": "https://www.home-assistant.io/integrations/smartlife",
+  "documentation": "https://github.com/tuya/tuya-smart-life",
   "integration_type": "hub",
   "iot_class": "cloud_push",
   "version": "0.1.0",


### PR DESCRIPTION
The documentation URL should point to GitHub in the absence of a page on home assistant.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)